### PR TITLE
Add Current support for ECM-1240/ECM-1220

### DIFF
--- a/bin/btmon.py
+++ b/bin/btmon.py
@@ -1662,6 +1662,8 @@ class ECM1220BinaryPacket(ECMBinaryPacket):
         c = []
         if fltr == FILTER_PE_LABELS:
             c = ['ch1', 'ch2']
+        elif fltr == FILTER_CURRENT:
+            c = ['ch1_a', 'ch2_a']
         elif fltr == FILTER_POWER:
             c = ['ch1_w', 'ch2_w']
         elif fltr == FILTER_ENERGY:
@@ -1754,6 +1756,8 @@ class ECM1240BinaryPacket(ECM1220BinaryPacket):
         c = []
         if fltr == FILTER_PE_LABELS:
             c = ['ch1', 'ch2', 'aux1', 'aux2', 'aux3', 'aux4', 'aux5']
+        elif fltr == FILTER_CURRENT:
+            c = ['ch1_a', 'ch2_a']
         elif fltr == FILTER_POWER:
             c = ['ch1_w', 'ch2_w', 'aux1_w', 'aux2_w', 'aux3_w', 'aux4_w', 'aux5_w']
         elif fltr == FILTER_ENERGY:


### PR DESCRIPTION
Adding Current filter support for ECM-1240 and ECM-1220 to match the GEM capability.

This functionality came up as part of the discussion for Issue https://github.com/matthewwall/mtools/issues/8#issuecomment-252522655

Signed-off-by: Mark Clark mr.guessed@gmail.com (github: mrguessed)
